### PR TITLE
Revert "Add composer script to auto-copy templates"

### DIFF
--- a/sylius/plus/1.0/manifest.json
+++ b/sylius/plus/1.0/manifest.json
@@ -8,9 +8,6 @@
                 "copy-from-recipe": {
                     "config/": "%CONFIG_DIR%/",
                     "src/": "%SRC_DIR%/"
-                },
-                "composer-scripts": {
-                    "cp -fr vendor/sylius/plus/src/Resources/templates/bundles/* templates/bundles": "script"
                 }
             },
             "files": {
@@ -239,7 +236,7 @@
                     "executable": false
                 }
             },
-            "ref": "6ba0c766b80b1c760648b13c17480d689be6d2eb"
+            "ref": "83ca3b38f6e5bc11c9a16d963db6ed4064820611"
         }
     }
 }


### PR DESCRIPTION
This reverts commit b5e9e595cf584c1e0e68c42ccf2c284159abd2c0.

There is option to add the scripts only to `auto-scripts` and I don't think we want it to always execute